### PR TITLE
simplify records: remove most allocations + misc

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,11 @@ const AtomRecord = @import("records.zig").AtomRecord;
 const RunRecord = @import("records.zig").RunRecord;
 const PDBReader = @import("records.zig").PDBReader;
 
+test {
+    // this causes 'zig build test' to test any referenced files
+    _ = @import("records.zig");
+}
+
 const Args = struct {
     runs: u64 = 100,
     fileName: string = "",
@@ -57,8 +62,7 @@ pub fn main() !void {
         var atoms = try PDBReader(read, allocator);
         defer atoms.deinit();
         for (atoms.items) |*atom| {
-            try atom.print();
-            try atom.free(allocator);
+            std.debug.print("{}\n", .{atom});
         }
         std.os.exit(0);
     }
@@ -85,7 +89,7 @@ pub fn main() !void {
         var elapsed = timer.read();
         try times.append(elapsed);
         var runRecord: RunRecord = RunRecord{ .run = i + 1, .time = elapsed, .file = parsedArgs.fileName };
-        try runRecord.writeCSVLine(allocator, csv);
+        try runRecord.writeCSVLine(csv);
         sum += elapsed;
         std.debug.print("Run {} Complete\n", .{i});
     }

--- a/src/records.zig
+++ b/src/records.zig
@@ -121,7 +121,7 @@ pub const AtomRecord = struct {
         allocator.free(self.element);
         allocator.free(self.entry);
         allocator.free(self.name);
-        // allocator.free(self.record);
+        allocator.free(self.record);
         allocator.free(self.resName);
     }
 };
@@ -165,7 +165,7 @@ const Line = extern struct {
 
     fn convertToAtomRecord(self: *const Line, serialIndex: u32, allocator: std.mem.Allocator) !AtomRecord {
         var atom: AtomRecord = undefined;
-        atom.record = strings.removeSpaces(&self.record);
+        atom.record = try allocator.dupe(u8, strings.removeSpaces(&self.record));
         atom.serial = std.fmt.parseInt(u32, strings.removeSpaces(&self.serial), 10) catch serialIndex + 1;
         atom.name = try allocator.dupe(u8, strings.removeSpaces(&self.name));
         atom.altLoc = if (self.altLoc[0] == 32) null else self.altLoc[0];

--- a/src/strings.zig
+++ b/src/strings.zig
@@ -1,29 +1,11 @@
 const std = @import("std");
 pub fn equals(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) {
-        return false;
-    }
-    for (a, b) |aItem, bItem| {
-        if (bItem != aItem) {
-            return false;
-        }
-    }
-    return true;
+    return std.mem.eql(u8, a, b);
 }
 pub fn removeSpaces(s: []const u8) []const u8 {
     return std.mem.trim(u8, s, " ");
 }
 
-pub fn removeSpacesAlloc(s: []const u8, allocator: std.mem.Allocator) ![]const u8 {
-    const trimmed = std.mem.trim(u8, s, " ");
-    const record = try allocator.alloc(u8, trimmed.len);
-    @memcpy(record, trimmed);
-    return record;
-}
-
 test "removeSpaces" {
-    const s = [_]u8{ 'A', 'T', 'O', 'M', ' ', ' ' };
-    const expected: []const u8 = "ATOM";
-    const actual = removeSpaces(&s);
-    try std.testing.expect(equals(expected, actual));
+    try std.testing.expectEqualStrings("ATOM", removeSpaces("ATOM  "));
 }


### PR DESCRIPTION
i caught some of the most recent vod and was thinking: i know that this can be done very simply and without allocating any memory.  and i also noticed you were a little frustrated with the tests not printing expected/actual values. so i thought these changes might ease some of the problems you were running into.

forgive me for putting this all in one commit and for making so many changes.  i hope it makes sense and is useful.  i've written a lot of comments, more than i usually would as i know may come at you out of nowhere.

hope this isn't too stale as it seems like you've moved ahead from this commit earlier today.  if so, take it or leave it.  i just thought you might like some of these changes.

* add atom format() method which also prints json
* new() becomes trivial with an extern struct
* tests: add expectEqual helper + use testing.expectEqualStrings
* 'zig build test' now runs tests in records.zig